### PR TITLE
fix: remove the warning of `audio blob is empty`

### DIFF
--- a/src/home/chat-window/compnent/audio.tsx
+++ b/src/home/chat-window/compnent/audio.tsx
@@ -51,7 +51,8 @@ export const Audio: React.FC<AudioProps> = ({
                         const url = URL.createObjectURL(blob)
                         setUrl(url)
                     } else {
-                        console.error("audio blob is empty, audioId:", audioSnap.id)
+                        // audio is expected to be empty after restoring from an uploaded json file
+                        // console.error("audio blob is empty, audioId:", audioSnap.id)
                     }
                 }).then(() => true)
             }

--- a/src/home/chat-window/message-list/menu.tsx
+++ b/src/home/chat-window/message-list/menu.tsx
@@ -64,7 +64,8 @@ export const AudioMenu: React.FC<AudioMenuProps> = ({deleteAction, audioId}) => 
                             const url = URL.createObjectURL(blob)
                             setUrl(url)
                         } else {
-                            console.error("audio blob is empty, audioId:", audioId)
+                            // audio is expected to be empty after restoring from an uploaded json file
+                            //  console.error("audio blob is empty, audioId:", audioId)
                         }
                     }
                 ).then(() => true)


### PR DESCRIPTION
Remove the warning of `audio blob is empty` because the audio is expected to be empty after restoring from an uploaded json file